### PR TITLE
[Bugfix] 当标题带有类似xxx.js文件名时结尾会被转大写JS

### DIFF
--- a/AutoCorrect.php
+++ b/AutoCorrect.php
@@ -30,7 +30,7 @@ class AutoCorrect
     public function auto_correct($content)
     {
         foreach ($this->dicts as $from => $to) {
-            $content = preg_replace("/\b$from\b/i", $to, $content);
+            $content = preg_replace("/(?<!\.|[a-z]){$from}(?!\.|[a-z])/i", $to, $content);
         }
 
         return $content;


### PR DESCRIPTION
今天在 PHPHub 发贴的时候发现的这个问题，修复测试：

``` php
<?php

$from = "js";
$to = 'JS';
$contents = [
    '你一直在寻找的社交分享组件 overtrue/share.js',
    '你一直在寻找的社交分享组件 overtrue/share.js已经开源啦',
    '你一直在寻找的社交分享组件 overtrue/share.js 已经开源啦',
    'js 是一门脚本语言',
    'js是一门脚本语言',
    '-js是一门脚本语言 jsx ',
    ' js是一门脚本语言js',
    '大家所说的js.是一门脚本语言',
    '大家所说的js。是一门脚本语言',
    '大家所说的 js是一门脚本语言',
    '大家所说的 js 是一门脚本语言',
    '大家所说的 ejs 是一个js模板',
];

$regex = "/(?<!\.|[a-z]){$from}(?!\.|[a-z])/i";

foreach ($contents as $content) {
    echo preg_replace($regex, "\1{$to}", $content), "\n";
}

```

> 你一直在寻找的社交分享组件 overtrue/share.js
> 你一直在寻找的社交分享组件 overtrue/share.js已经开源啦
> 你一直在寻找的社交分享组件 overtrue/share.js 已经开源啦
> JS 是一门脚本语言
> JS是一门脚本语言
> -JS是一门脚本语言 jsx
>  JS是一门脚本语言JS
> 大家所说的js.是一门脚本语言
> 大家所说的JS。是一门脚本语言
> 大家所说的 JS是一门脚本语言
> 大家所说的 JS 是一门脚本语言
> 大家所说的 ejs 是一个JS模板
